### PR TITLE
feat: update person card interface

### DIFF
--- a/src/components/Person/Card.tsx
+++ b/src/components/Person/Card.tsx
@@ -44,7 +44,7 @@ export const PersonCard: React.FC<PersonCardProps> = (props) => {
         closeIcon
         trigger={trigger}
         dimmer={{ inverted: true }}
-        size='large'
+        size="large"
       >
         <Modal.Header>
           {oier.name}

--- a/src/components/Person/Card.tsx
+++ b/src/components/Person/Card.tsx
@@ -44,6 +44,7 @@ export const PersonCard: React.FC<PersonCardProps> = (props) => {
         closeIcon
         trigger={trigger}
         dimmer={{ inverted: true }}
+        size='large'
       >
         <Modal.Header>
           {oier.name}

--- a/src/components/Person/index.module.less
+++ b/src/components/Person/index.module.less
@@ -15,3 +15,20 @@
     margin-right: 4px;
   }
 }
+
+.progress-0 { color: hsl(0, 100%, 50%); }
+.progress-1 { color: hsl(12, 100%, 48%); }
+.progress-2 { color: hsl(24, 100%, 46%); }
+.progress-3 { color: hsl(36, 100%, 44%); }
+.progress-4 { color: hsl(48, 100%, 42%); }
+.progress-5 { color: hsl(60, 100%, 40%); }
+.progress-6 { color: hsl(72, 100%, 40%); }
+.progress-7 { color: hsl(84, 100%, 40%); }
+.progress-8 { color: hsl(96, 100%, 40%); }
+.progress-9 { color: hsl(108, 100%, 40%); }
+.progress-10 { color: hsl(120, 100%, 40%); }
+
+.recordTotal {
+  color: #ccc;
+  font-size: smaller;
+}

--- a/src/components/Person/index.tsx
+++ b/src/components/Person/index.tsx
@@ -42,6 +42,12 @@ export const Person: React.FC<PersonProps> = memo((props) => {
     return contestName.replace(/(\d+)([a-z]+)/gi, '$1 $2');
   }
 
+  function getProgress(score: number, fullScore: number) {
+    if (!(score < fullScore)) return 10;
+    if (!(0 < score)) return 0;
+    return Math.floor(10 * score / fullScore);
+  }
+
   return (
     <>
       <h4>选手信息</h4>
@@ -61,6 +67,7 @@ export const Person: React.FC<PersonProps> = memo((props) => {
             <Table.HeaderCell>奖项</Table.HeaderCell>
             <Table.HeaderCell>分数</Table.HeaderCell>
             <Table.HeaderCell>选手排名</Table.HeaderCell>
+            <Table.HeaderCell>省份</Table.HeaderCell>
             <Table.HeaderCell>就读学校</Table.HeaderCell>
             <Table.HeaderCell>年级</Table.HeaderCell>
           </Table.Row>
@@ -77,8 +84,34 @@ export const Person: React.FC<PersonProps> = memo((props) => {
                   {fixChineseSpace(data.level)}
                 </span>
               </Table.Cell>
-              <Table.Cell>{data.score}</Table.Cell>
-              <Table.Cell>{data.rank}</Table.Cell>
+              <Table.Cell>
+                {data.score == null ? '/' :
+                  <>
+                    <span className={styles[`progress-${getProgress(
+                      data.score, data.contest.full_score
+                    )}`]}>
+                      {data.score}
+                    </span>
+                    {' '}
+                    <span className={styles.recordTotal}>
+                      / {data.contest.full_score}
+                    </span>
+                  </>
+                }
+              </Table.Cell>
+              <Table.Cell>
+                <span className={styles[`progress-${getProgress(
+                  data.contest.n_contestants() - data.rank,
+                  data.contest.n_contestants() - 1
+                )}`]}>
+                  {data.rank}
+                </span>
+                {' '}
+                <span className={styles.recordTotal}>
+                  / {data.contest.n_contestants()}
+                </span>
+              </Table.Cell>
+              <Table.Cell>{data.province}</Table.Cell>
               <Table.Cell>
                 <Link to={`/school/${data.school.id}`}>{data.school.name}</Link>
               </Table.Cell>
@@ -102,7 +135,7 @@ export const Person: React.FC<PersonProps> = memo((props) => {
                 )}
               </Table.Cell>
             </Table.Row>
-          ))}
+          )).reverse()}
         </Table.Body>
       </Table>
     </>

--- a/src/components/Person/index.tsx
+++ b/src/components/Person/index.tsx
@@ -45,7 +45,7 @@ export const Person: React.FC<PersonProps> = memo((props) => {
   function getProgress(score: number, fullScore: number) {
     if (!(score < fullScore)) return 10;
     if (!(0 < score)) return 0;
-    return Math.floor(10 * score / fullScore);
+    return Math.floor((10 * score) / fullScore);
   }
 
   return (
@@ -73,69 +73,86 @@ export const Person: React.FC<PersonProps> = memo((props) => {
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {oier.records.map((data) => (
-            <Table.Row key={data.contest.id}>
-              <Table.Cell>
-                <span className={styles.contestName}>
-                  {fixChineseSpace(fixContestName(data.contest.name))}
-                </span>{' '}
-                <span className={styles.contestLevel}>
-                  <AwardEmoji level={data.level} />
-                  {fixChineseSpace(data.level)}
-                </span>
-              </Table.Cell>
-              <Table.Cell>
-                {data.score == null ? '/' :
-                  <>
-                    <span className={styles[`progress-${getProgress(
-                      data.score, data.contest.full_score
-                    )}`]}>
-                      {data.score}
-                    </span>
-                    {' '}
-                    <span className={styles.recordTotal}>
-                      / {data.contest.full_score}
-                    </span>
-                  </>
-                }
-              </Table.Cell>
-              <Table.Cell>
-                <span className={styles[`progress-${getProgress(
-                  data.contest.n_contestants() - data.rank,
-                  data.contest.n_contestants() - 1
-                )}`]}>
-                  {data.rank}
-                </span>
-                {' '}
-                <span className={styles.recordTotal}>
-                  / {data.contest.n_contestants()}
-                </span>
-              </Table.Cell>
-              <Table.Cell>{data.province}</Table.Cell>
-              <Table.Cell>
-                <Link to={`/school/${data.school.id}`}>{data.school.name}</Link>
-              </Table.Cell>
-              <Table.Cell>
-                {data.enroll_middle &&
-                data.enroll_middle !== oier.enroll_middle ? (
-                  <Popup
-                    position="top center"
-                    content="此记录为非正常年级，可能为该选手后期出现了留级等情况而导致的。"
-                    trigger={
-                      <span style={{ color: 'red' }}>
-                        {getGrade(
-                          data.enroll_middle,
-                          data.contest.school_year()
-                        )}
+          {oier.records
+            .map((data) => (
+              <Table.Row key={data.contest.id}>
+                <Table.Cell>
+                  <span className={styles.contestName}>
+                    {fixChineseSpace(fixContestName(data.contest.name))}
+                  </span>{' '}
+                  <span className={styles.contestLevel}>
+                    <AwardEmoji level={data.level} />
+                    {fixChineseSpace(data.level)}
+                  </span>
+                </Table.Cell>
+                <Table.Cell>
+                  {data.score == null ? (
+                    '/'
+                  ) : (
+                    <>
+                      <span
+                        className={
+                          styles[
+                            `progress-${getProgress(
+                              data.score,
+                              data.contest.full_score
+                            )}`
+                          ]
+                        }
+                      >
+                        {data.score}
+                      </span>{' '}
+                      <span className={styles.recordTotal}>
+                        / {data.contest.full_score}
                       </span>
+                    </>
+                  )}
+                </Table.Cell>
+                <Table.Cell>
+                  <span
+                    className={
+                      styles[
+                        `progress-${getProgress(
+                          data.contest.n_contestants() - data.rank,
+                          data.contest.n_contestants() - 1
+                        )}`
+                      ]
                     }
-                  />
-                ) : (
-                  getGrade(oier.enroll_middle, data.contest.school_year())
-                )}
-              </Table.Cell>
-            </Table.Row>
-          )).reverse()}
+                  >
+                    {data.rank}
+                  </span>{' '}
+                  <span className={styles.recordTotal}>
+                    / {data.contest.n_contestants()}
+                  </span>
+                </Table.Cell>
+                <Table.Cell>{data.province}</Table.Cell>
+                <Table.Cell>
+                  <Link to={`/school/${data.school.id}`}>
+                    {data.school.name}
+                  </Link>
+                </Table.Cell>
+                <Table.Cell>
+                  {data.enroll_middle &&
+                  data.enroll_middle !== oier.enroll_middle ? (
+                    <Popup
+                      position="top center"
+                      content="此记录为非正常年级，可能为该选手后期出现了留级等情况而导致的。"
+                      trigger={
+                        <span style={{ color: 'red' }}>
+                          {getGrade(
+                            data.enroll_middle,
+                            data.contest.school_year()
+                          )}
+                        </span>
+                      }
+                    />
+                  ) : (
+                    getGrade(oier.enroll_middle, data.contest.school_year())
+                  )}
+                </Table.Cell>
+              </Table.Row>
+            ))
+            .reverse()}
         </Table.Body>
       </Table>
     </>

--- a/src/libs/OIerDb.ts
+++ b/src/libs/OIerDb.ts
@@ -39,11 +39,17 @@ export class Contest {
   type: string;
   contestants: Record[];
   fall_semester: boolean;
+  full_score: number;
+  capacity: number;
   length: number;
   level_counts: Counter;
 
   school_year(): number {
     return this.fall_semester ? this.year : this.year - 1;
+  }
+
+  n_contestants() {
+    return this.capacity ? this.capacity : this.contestants.length;
   }
 }
 


### PR DESCRIPTION
更新选手信息界面。主要变动：

* 将记录的顺序改为时间倒序（新的比赛放在最前面）；
* 增加了满分和排名标识，以及用颜色强调数据。
* 稍微增加（补充）了部分接口。

效果图：
![effe](https://user-images.githubusercontent.com/31309196/176572253-5b8fa2a5-d702-4760-84e3-0b70c59afc0a.png)
