### PR TITLE
perf: 优化数据解析速度

### DIFF
--- a/src/libs/Counter.ts
+++ b/src/libs/Counter.ts
@@ -4,7 +4,7 @@ export class Counter<K> extends Map<K, number> {
     super(entries);
   }
 
-  _counter_common(n: number, k: 1 | -1) {
+  private _counter_common(n: number, k: 1 | -1) {
     const all = [...this.entries()].sort((x, y) => {
       if (x[1] !== y[1]) return k * (y[1] - x[1]);
       return x[0] < y[0] ? -1 : x[0] > y[0] ? 1 : 0;

--- a/src/libs/Counter.ts
+++ b/src/libs/Counter.ts
@@ -4,7 +4,7 @@ export class Counter<K> extends Map<K, number> {
     super(entries);
   }
 
-  #counter_common(n: number, k: 1 | -1) {
+  _counter_common(n: number, k: 1 | -1) {
     const all = [...this.entries()].sort((x, y) => {
       if (x[1] !== y[1]) return k * (y[1] - x[1]);
       return x[0] < y[0] ? -1 : x[0] > y[0] ? 1 : 0;
@@ -17,11 +17,11 @@ export class Counter<K> extends Map<K, number> {
   }
 
   least_common(n: number) {
-    return this.#counter_common(n, -1);
+    return this._counter_common(n, -1);
   }
 
   most_common(n: number) {
-    return this.#counter_common(n, 1);
+    return this._counter_common(n, 1);
   }
 
   update(key: K, value = 1) {


### PR DESCRIPTION
将Counter的私有函数改为公有函数，以此避免类初始化时由于私有函数检查导致的性能损耗。

加载时间可缩短近5倍。
### Before
![image](https://github.com/user-attachments/assets/dad0e86f-7829-4210-95b0-a0e0eb6a4be7)

[Trace-before.json.gz](https://github.com/user-attachments/files/18410488/Trace-before.json.gz)
### After
![image](https://github.com/user-attachments/assets/9eaedb1e-1d01-4677-ae7e-13a0ced287fb)

[Trace-after.json.gz](https://github.com/user-attachments/files/18410490/Trace-after.json.gz)
